### PR TITLE
Cron yaml matches cluster

### DIFF
--- a/infrastructure/k8s/bin/helmit.py
+++ b/infrastructure/k8s/bin/helmit.py
@@ -77,7 +77,7 @@ def render_cronjob(project_name, secret_keys, deployment):
     context.update(deployment)
     format_values(context)
     template = yaml.load(open("templates/cron-job.yaml"), Loader=yaml.SafeLoader)
-    suffix = f"cron-{context['job_name']}"
+    suffix = f"cron-{context['job_name'].lower()}"
     write_file(template, context, suffix)
 
 

--- a/infrastructure/k8s/templates/cron-job.yaml
+++ b/infrastructure/k8s/templates/cron-job.yaml
@@ -4,26 +4,15 @@ metadata:
   name: ${project_name}-${lowercase(job_name)}
 spec:
   schedule: ${schedule}
-  concurrencyPolicy: Allow
-  failedJobsHistoryLimit: 1
-  successfulJobsHistoryLimit: 3
-  suspend: false
   jobTemplate:
     metadata:
-      creationTimestamp: null
       labels:
         application: taskcluster
         taskcluster-service: ${project_name}
     spec:
       template:
-        metadata:
-          creationTimestamp: null
         spec:
-          dnsPolicy: ClusterFirst
           restartPolicy: OnFailure
-          schedulerName: default-scheduler
-          securityContext: {}
-          terminationGracePeriodSeconds: 30
           activeDeadlineSeconds: {$eval: 'deadline_seconds'}
           volumes:
             $if: 'len(volume_mounts) > 0'
@@ -40,8 +29,6 @@ spec:
           - name: ${project_name}-${lowercase(job_name)}
             image: ${docker_image}
             imagePullPolicy: Always
-            terminationMessagePath: /dev/termination-log
-            terminationMessagePolicy: File
             args:
               $if: 'is_monoimage'
               then: ['${service_name}/${job_name}']
@@ -70,4 +57,3 @@ spec:
                       secretKeyRef:
                         name: '${secret_name}'
                         key: '${uppercase(k)}'
-status: {}

--- a/infrastructure/k8s/templates/cron-job.yaml
+++ b/infrastructure/k8s/templates/cron-job.yaml
@@ -4,15 +4,26 @@ metadata:
   name: ${project_name}-${lowercase(job_name)}
 spec:
   schedule: ${schedule}
+  concurrencyPolicy: Allow
+  failedJobsHistoryLimit: 1
+  successfulJobsHistoryLimit: 3
+  suspend: false
   jobTemplate:
     metadata:
+      creationTimestamp: null
       labels:
         application: taskcluster
         taskcluster-service: ${project_name}
     spec:
       template:
+        metadata:
+          creationTimestamp: null
         spec:
+          dnsPolicy: ClusterFirst
           restartPolicy: OnFailure
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
           activeDeadlineSeconds: {$eval: 'deadline_seconds'}
           volumes:
             $if: 'len(volume_mounts) > 0'
@@ -29,6 +40,8 @@ spec:
           - name: ${project_name}-${lowercase(job_name)}
             image: ${docker_image}
             imagePullPolicy: Always
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
             args:
               $if: 'is_monoimage'
               then: ['${service_name}/${job_name}']
@@ -52,8 +65,9 @@ spec:
                   value: ${root_url}
                 - $map: {$eval: 'secret_keys'}
                   each(k):
-                    name: '${k}'
+                    name: '${uppercase(k)}'
                     valueFrom:
                       secretKeyRef:
                         name: '${secret_name}'
-                        key: '${k}'
+                        key: '${uppercase(k)}'
+status: {}

--- a/infrastructure/k8s/templates/secret.yaml
+++ b/infrastructure/k8s/templates/secret.yaml
@@ -6,4 +6,4 @@ metadata:
 data:
   $map: {$eval: secrets}
   each(s):
-    ${s.key}: "{{ ${s.val} | b64enc }}"
+    ${uppercase(s.key)}: "{{ ${s.val} | b64enc }}"


### PR DESCRIPTION
This is the changeset that makes helmit's output look exactly like the kubectl export. 

Let's discuss whether including the null `creationTimestamp` (it's null across all crons in the cluster as retrieved w/ kubectl), the empty `status`, etc are actually things we should be including ourselves or if they came from kubernetes. 