### PR TITLE
Terraform: put back what gives the users their perms

### DIFF
--- a/infrastructure/terraform/github-service.tf
+++ b/infrastructure/terraform/github-service.tf
@@ -1,0 +1,7 @@
+module "github_rabbitmq_user" {
+  source         = "modules/rabbitmq-user"
+  prefix         = "${var.prefix}"
+  project_name   = "taskcluster-github"
+  rabbitmq_vhost = "${var.rabbitmq_vhost}"
+}
+

--- a/infrastructure/terraform/hooks-service.tf
+++ b/infrastructure/terraform/hooks-service.tf
@@ -1,0 +1,7 @@
+module "hooks_rabbitmq_user" {
+  source         = "modules/rabbitmq-user"
+  prefix         = "${var.prefix}"
+  project_name   = "taskcluster-hooks"
+  rabbitmq_vhost = "${var.rabbitmq_vhost}"
+}
+

--- a/infrastructure/terraform/index-service.tf
+++ b/infrastructure/terraform/index-service.tf
@@ -1,0 +1,7 @@
+module "index_rabbitmq_user" {
+  source         = "modules/rabbitmq-user"
+  prefix         = "${var.prefix}"
+  project_name   = "taskcluster-index"
+  rabbitmq_vhost = "${var.rabbitmq_vhost}"
+}
+

--- a/infrastructure/terraform/secrets-service.tf
+++ b/infrastructure/terraform/secrets-service.tf
@@ -1,0 +1,7 @@
+module "secrets_rabbitmq_user" {
+  source         = "modules/rabbitmq-user"
+  prefix         = "${var.prefix}"
+  project_name   = "taskcluster-secrets"
+  rabbitmq_vhost = "${var.rabbitmq_vhost}"
+}
+

--- a/infrastructure/terraform/web-server-service.tf
+++ b/infrastructure/terraform/web-server-service.tf
@@ -1,0 +1,7 @@
+module "web_server_rabbitmq_user" {
+  source         = "modules/rabbitmq-user"
+  prefix         = "${var.prefix}"
+  project_name   = "taskcluster-web-server"
+  rabbitmq_vhost = "${var.rabbitmq_vhost}"
+}
+


### PR DESCRIPTION
Will handle notify and auth in their respective PRs, as those are still open. 