### PR TITLE
Inject logging settings where env var settings go

### DIFF
--- a/infrastructure/k8s/bin/helmit.py
+++ b/infrastructure/k8s/bin/helmit.py
@@ -37,6 +37,8 @@ def render_rbac(project_name):
 
 
 def render_secrets(project_name, secrets):
+    secrets['debug'] = '*'
+    secrets['level'] = 'TRACE'
     format_secrets(secrets)
     context = {"project_name": project_name, "secrets": secrets}
     template = yaml.load(open("templates/secret.yaml"), Loader=yaml.SafeLoader)

--- a/infrastructure/k8s/templates/secret.yaml
+++ b/infrastructure/k8s/templates/secret.yaml
@@ -4,6 +4,6 @@ type: Opaque
 metadata:
   name: ${project_name}
 data:
-  $map: {$merge: [{DEBUG: '*', LEVEL: 'TRACE'}, {$eval: secrets}]}
+  $map: {$eval: secrets}
   each(s):
     ${uppercase(s.key)}: "{{ ${s.val} | b64enc }}"


### PR DESCRIPTION
edunham [6:28 PM]
Not actually fun. Everything is awful. The branch `logging-again` of your Taskcluster repo holds a fix that sidesteps the hell that is trying to send through the right amount of escaping around that bloody asterisk.