### PR TITLE
Initial pass at ingress

### DIFF
--- a/infrastructure/k8s/bin/helmit.py
+++ b/infrastructure/k8s/bin/helmit.py
@@ -3,10 +3,10 @@
 import argparse
 import glob
 import jsone
-import yaml
 import os
+import shutil
+import yaml
 
-# todo: add secret hash calculation to deployment
 # todo: make things work no matter cwd and os
 
 # secrets are interpolated by json-e into this goland template expression
@@ -88,6 +88,10 @@ def render_cronjob(project_name, secret_keys, deployment):
     write_file(template, context, suffix)
 
 
+def render_ingress():
+    shutil.copy("ingress/ingress.yaml", args.chartsdir)
+
+
 def write_file(template, context, suffix):
     filepath = f"{args.chartsdir}/{context['project_name']}-{suffix}.yaml"
     try:
@@ -114,6 +118,9 @@ if args.service:
     service_declarations = [f"services/{args.service}.yaml"]
 else:
     service_declarations = glob.glob("services/*yaml")
+
+# in the future may support multiple styles of ingress
+render_ingress()
 
 for p in service_declarations:
     declaration = yaml.load(open(p), Loader=yaml.SafeLoader)

--- a/infrastructure/k8s/ingress/ingress.yaml
+++ b/infrastructure/k8s/ingress/ingress.yaml
@@ -1,0 +1,68 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: taskcluster-ingress
+  annotations:
+    kubernetes.io/ingress.global-static-ip-name: {{ .Values.ingressStaticIpName }}
+    ingress.gcp.kubernetes.io/pre-shared-cert: {{ .Values.ingressCertName }}
+spec:
+  rules:
+  - http:
+      paths:
+       - path: '/*'
+         backend:
+           #serviceName: taskcluster-ui
+           serviceName: taskcluster-references # hack until taskcluster-ui is working
+           servicePort: 80
+       - path: '/references/*'
+         backend:
+           serviceName: taskcluster-references
+           servicePort: 80
+       - path: '/schemas/*'
+         backend:
+           serviceName: taskcluster-references
+           servicePort: 80
+       - path: '/graphql/*'
+         backend:
+           serviceName: taskcluster-web-server
+           servicePort: 80
+#       - path: '/api/auth/*'
+#         backend:
+#           serviceName:  taskcluster-auth
+#           servicePort: 80
+#       - path: '/api/secrets/*'
+#         backend:
+#           serviceName:  taskcluster-secrets
+#           servicePort: 80
+#       - path: '/api/queue/*'
+#         backend:
+#           serviceName:  taskcluster-queue
+#           servicePort: 80
+#       - path: '/api/hooks/*'
+#         backend:
+#           serviceName:  taskcluster-hooks
+#           servicePort: 80
+#       - path: '/api/index/*'
+#         backend:
+#           serviceName:  taskcluster-index
+#           servicePort: 80
+#       - path: '/api/events/*'
+#         backend:
+#           serviceName:  taskcluster-events
+#           servicePort: 80
+#       - path: '/api/notify/*'
+#         backend:
+#           serviceName:  taskcluster-notify
+#           servicePort: 80
+#       - path: '/api/purge-cache/*'
+#         backend:
+#           serviceName:  taskcluster-purge-cache
+#           servicePort: 80
+#       - path: '/api/github/*'
+#         backend:
+#           serviceName:  taskcluster-github
+#           servicePort: 80
+#       - path: '/api/worker-manager/*'
+#         backend:
+#           serviceName:  taskcluster-worker-manager
+#           servicePort: 80


### PR DESCRIPTION
This sets up an ingress that points to the deployments which we have
successfully responding to the readiness checks.

Since ui is not working yet i temporarily pointed the root url at
references

https://stage.taskcluster.nonprod.cloudops.mozgcp.net/
https://stage.taskcluster.nonprod.cloudops.mozgcp.net/references/
https://stage.taskcluster.nonprod.cloudops.mozgcp.net/graphql/