### PR TITLE
Reload secrets

### DIFF
--- a/infrastructure/k8s/bin/helmit.py
+++ b/infrastructure/k8s/bin/helmit.py
@@ -58,6 +58,8 @@ def render_deployment(project_name, secret_keys, deployment):
         "replicas": "1",
         "background_job": False,
         "is_monoimage": True,
+        # doing this ugly thing here because attempting to do it in jsone turned out even worse
+        "checksum_calculation": "{{ " + f'include (print $.Template.BasePath "/{project_name}-secrets.yaml") . | sha256sum' + " }}"
     }
     context.update(deployment)
     format_values(context)
@@ -96,7 +98,7 @@ def write_file(template, context, suffix):
     filepath = f"{args.chartsdir}/{context['project_name']}-{suffix}.yaml"
     try:
         f = open(filepath, "w+")
-        f.write(yaml.dump(jsone.render(template, context), default_flow_style=False))
+        f.write(yaml.dump(jsone.render(template, context), default_flow_style=False, width=float("inf")))
         f.close()
     except:
         print(f"failed to write {filepath}")

--- a/infrastructure/k8s/services/built-in-workers.yaml
+++ b/infrastructure/k8s/services/built-in-workers.yaml
@@ -8,7 +8,6 @@ secrets:
 deployments:
   - service_name: "built-in-workers"
     proc_name: "server"
-    secret_name: "taskcluster-built-in-workers"
     root_url: ".Values.rootUrl"
     docker_image: ".Values.dockerImage"
     background_job: true

--- a/infrastructure/k8s/services/github.yaml
+++ b/infrastructure/k8s/services/github.yaml
@@ -21,13 +21,11 @@ deployments:
     proc_name: "web"
     readiness_path: "/api/github/v1/ping"
     root_url: ".Values.rootUrl"
-    secret_name: "taskcluster-github"
   - service_name: "github"
     background_job: true
     docker_image: ".Values.dockerImage"
     proc_name: "worker"
     root_url: ".Values.rootUrl"
-    secret_name: "taskcluster-github"
 cronjobs:
   - service_name: "github"
     deadline_seconds: 86400
@@ -35,4 +33,3 @@ cronjobs:
     job_name: "sync"
     root_url: ".Values.rootUrl"
     schedule: "0 0 * * *"
-    secret_name: "taskcluster-github"

--- a/infrastructure/k8s/services/hooks.yaml
+++ b/infrastructure/k8s/services/hooks.yaml
@@ -23,19 +23,16 @@ deployments:
     proc_name: "web"
     readiness_path: "/api/hooks/v1/ping"
     root_url: ".Values.rootUrl"
-    secret_name: "taskcluster-hooks"
   - service_name: "hooks"
     background_job: true
     docker_image: ".Values.dockerImage"
     proc_name: "scheduler"
     root_url: ".Values.rootUrl"
-    secret_name: "taskcluster-hooks"
   - service_name: "hooks"
     background_job: true
     docker_image: ".Values.dockerImage"
     proc_name: "listeners"
     root_url: ".Values.rootUrl"
-    secret_name: "taskcluster-hooks"
 cronjobs:
   - service_name: "hooks"
     deadline_seconds: 86400
@@ -43,4 +40,3 @@ cronjobs:
     job_name: "expires"
     root_url: ".Values.rootUrl"
     schedule: "10 0 * * *"
-    secret_name: "taskcluster-hooks"

--- a/infrastructure/k8s/services/index.yaml
+++ b/infrastructure/k8s/services/index.yaml
@@ -18,12 +18,10 @@ deployments:
     proc_name: "web"
     readiness_path: "/api/index/v1/ping"
     root_url: ".Values.rootUrl"
-    secret_name: "taskcluster-index"
   - service_name: "index"
     docker_image: ".Values.dockerImage"
     proc_name: "handlers"
     root_url: ".Values.rootUrl"
-    secret_name: "taskcluster-index"
 cronjobs:
   - service_name: "index"
     deadline_seconds: 86400
@@ -32,4 +30,3 @@ cronjobs:
     project_name: "taskcluster-index"
     root_url: ".Values.rootUrl"
     schedule: "0 0 * * *"
-    secret_name: "taskcluster-index"

--- a/infrastructure/k8s/services/purge-cache.yaml
+++ b/infrastructure/k8s/services/purge-cache.yaml
@@ -14,7 +14,6 @@ deployments:
     proc_name: "web"
     readiness_path: "/api/cache/v1/ping"
     root_url: ".Values.rootUrl"
-    secret_name: "taskcluster-purge-cache"
 cronjobs:
   - service_name: "purge-cache"
     deadline_seconds: 86400
@@ -22,4 +21,3 @@ cronjobs:
     job_name: "expireCachePurges"
     root_url: ".Values.rootUrl"
     schedule: "0 0 * * *"
-    secret_name: "taskcluster-purge-cache"

--- a/infrastructure/k8s/services/references.yaml
+++ b/infrastructure/k8s/services/references.yaml
@@ -7,4 +7,3 @@ deployments:
     proc_name: "web"
     readiness_path: "/references/"
     root_url: ".Values.rootUrl"
-    secret_name: "taskcluster-references"

--- a/infrastructure/k8s/services/secrets.yaml
+++ b/infrastructure/k8s/services/secrets.yaml
@@ -18,7 +18,6 @@ deployments:
     proc_name: "web"
     readiness_path: "/api/secrets/v1/ping"
     root_url: ".Values.rootUrl"
-    secret_name: "taskcluster-secrets"
 cronjobs:
   - service_name: "secrets"
     deadline_seconds: 600
@@ -26,4 +25,3 @@ cronjobs:
     job_name: "expire"
     root_url: ".Values.rootUrl"
     schedule: "0 * * * *"
-    secret_name: "taskcluster-secrets"

--- a/infrastructure/k8s/services/ui.yaml
+++ b/infrastructure/k8s/services/ui.yaml
@@ -12,4 +12,3 @@ deployments:
     proc_name: "web"
     readiness_path: "/"
     root_url: ".Values.rootUrl"
-    secret_name: "taskcluster-ui"

--- a/infrastructure/k8s/services/web-server.yaml
+++ b/infrastructure/k8s/services/web-server.yaml
@@ -17,4 +17,3 @@ deployments:
     proc_name: "web"
     readiness_path: "/.well-known/apollo/server-health"
     root_url: ".Values.rootUrl"
-    secret_name: "taskcluster-web-server"

--- a/infrastructure/k8s/services/worker-manager.yaml
+++ b/infrastructure/k8s/services/worker-manager.yaml
@@ -14,10 +14,8 @@ deployments:
     proc_name: "web"
     readiness_path: "/api/worker-manager/v1/ping"
     root_url: ".Values.rootUrl"
-    secret_name: "taskcluster-worker-manager"
   - service_name: "worker-manager"
     background_job: true 
     docker_image: ".Values.dockerImage"
     proc_name: "provisioner"
     root_url: ".Values.rootUrl"
-    secret_name: "taskcluster-worker-manager"

--- a/infrastructure/k8s/templates/cronjob.yaml
+++ b/infrastructure/k8s/templates/cronjob.yaml
@@ -21,7 +21,7 @@ spec:
               each(mount):
                 name: ${mount.source}
                 secret:
-                  secretName: ${secret_name}
+                  secretName: ${project_name}
                   items:
                     - key: ${mount.source}
                       path: ${mount.name}
@@ -55,5 +55,5 @@ spec:
                     name: '${uppercase(k)}'
                     valueFrom:
                       secretKeyRef:
-                        name: '${secret_name}'
+                        name: '${project_name}'
                         key: '${uppercase(k)}'

--- a/infrastructure/k8s/templates/deployment.yaml
+++ b/infrastructure/k8s/templates/deployment.yaml
@@ -32,7 +32,7 @@ in:
             each(mount):
               name: ${mount.source}
               secret:
-                secretName: ${secret_name}
+                secretName: ${project_name}
                 items:
                   - key: ${mount.source}
                     path: ${mount.name}
@@ -61,7 +61,7 @@ in:
                   name: '${uppercase(k)}'
                   valueFrom:
                     secretKeyRef:
-                      name: '${secret_name}'
+                      name: '${project_name}'
                       key: '${uppercase(k)}'
           volumeMounts:
             $if: 'len(volume_mounts) > 0'

--- a/infrastructure/k8s/templates/deployment.yaml
+++ b/infrastructure/k8s/templates/deployment.yaml
@@ -18,7 +18,7 @@ in:
     template:
       metadata:
         annotations:
-          secrets_hash: todo_replace_me_with_calculation_in_helm
+          checksum/secret: ${checksum_calculation}
         labels:
           application: taskcluster
           taskcluster-service: ${project_name}


### PR DESCRIPTION
This results in the following helm for purge-cache

`checksum/secret: '{{ include (print $.Template.BasePath "/taskcluster-purge-cache-secrets.yaml") . | sha256sum }}'`

I rendered helm twice for it and got

```
checksum/secret: '411024c7c891f3efa82a604b2aad6a6383a4d4ca5a38a16d2bce126238fc005a'
```

both times

Then I changed a secret, did it again, and got

```
checksum/secret: '67d8a72cbeafb7b0342ff52365c7702f5d0236e283f41b0fd6208229d6f383ba'
```

so it's rendering as expected.

I was able to deploy the results to k8s.