### PR TITLE
Use envFrom to load secrets

### DIFF
--- a/infrastructure/k8s/bin/helmit.py
+++ b/infrastructure/k8s/bin/helmit.py
@@ -45,10 +45,9 @@ def render_secrets(project_name, secrets):
     write_file(template, context, "secrets")
 
 
-def render_deployment(project_name, secret_keys, deployment):
+def render_deployment(project_name, deployment):
     context = {
         "project_name": project_name,
-        "secret_keys": secret_keys,
         # below are default values
         "volume_mounts": [],
         "readiness_path": "/",
@@ -75,10 +74,9 @@ def render_deployment(project_name, secret_keys, deployment):
     write_file(template, context, suffix)
 
 
-def render_cronjob(project_name, secret_keys, deployment):
+def render_cronjob(project_name, deployment):
     context = {
         "project_name": project_name,
-        "secret_keys": secret_keys,
         # below are default values
         "volume_mounts": [],
         "is_monoimage": True,
@@ -127,11 +125,10 @@ render_ingress()
 for p in service_declarations:
     declaration = yaml.load(open(p), Loader=yaml.SafeLoader)
     project_name = declaration["project_name"]
-    secret_keys = list(declaration["secrets"].keys())
 
     render_secrets(project_name, declaration["secrets"])
     render_rbac(project_name)
     for deployment in declaration.get("deployments", []):
-        render_deployment(project_name, secret_keys, deployment)
+        render_deployment(project_name, deployment)
     for cronjob in declaration.get("cronjobs", []):
-        render_cronjob(project_name, secret_keys, cronjob)
+        render_cronjob(project_name, cronjob)

--- a/infrastructure/k8s/bin/helmit.py
+++ b/infrastructure/k8s/bin/helmit.py
@@ -38,7 +38,7 @@ def render_rbac(project_name):
 
 def render_secrets(project_name, secrets):
     secrets['debug'] = '*'
-    secrets['level'] = 'TRACE'
+    secrets['level'] = 'DEBUG'
     format_secrets(secrets)
     context = {"project_name": project_name, "secrets": secrets}
     template = yaml.load(open("templates/secret.yaml"), Loader=yaml.SafeLoader)

--- a/infrastructure/k8s/templates/cronjob.yaml
+++ b/infrastructure/k8s/templates/cronjob.yaml
@@ -50,10 +50,6 @@ spec:
               $flatten:
                 - name: TASKCLUSTER_ROOT_URL
                   value: ${root_url}
-                - $map: {$eval: 'secret_keys'}
-                  each(k):
-                    name: '${uppercase(k)}'
-                    valueFrom:
-                      secretKeyRef:
-                        name: '${project_name}'
-                        key: '${uppercase(k)}'
+            envFrom:
+              - secretRef:
+                  name: ${project_name}

--- a/infrastructure/k8s/templates/deployment.yaml
+++ b/infrastructure/k8s/templates/deployment.yaml
@@ -56,13 +56,9 @@ in:
                   value: '80'
               - name: TASKCLUSTER_ROOT_URL
                 value: ${root_url}
-              - $map: {$eval: 'secret_keys'}
-                each(k):
-                  name: '${uppercase(k)}'
-                  valueFrom:
-                    secretKeyRef:
-                      name: '${project_name}'
-                      key: '${uppercase(k)}'
+          envFrom:
+              - secretRef:
+                  name: ${project_name}
           volumeMounts:
             $if: 'len(volume_mounts) > 0'
             then:


### PR DESCRIPTION
Instead of explicitly listing each secret in deployment and cronjob,just use envfrom.
