### PR TITLE
Request more memory for UI

### DIFF
--- a/infrastructure/k8s/services/ui.yaml
+++ b/infrastructure/k8s/services/ui.yaml
@@ -8,7 +8,7 @@ deployments:
   - service_name: "ui"
     cpu: "100m"
     docker_image: ".Values.dockerImage"
-    memory: "400Mi"
+    memory: "2000Mi"
     proc_name: "web"
     readiness_path: "/"
     root_url: ".Values.rootUrl"


### PR DESCRIPTION
Previously this was causing nodes to go OOM, so I changed our node
type. Now it is still running out of memory, but I think it's because it
scheduled on nodes where its competing for memory. Will see if having it
reserve 2GB is enough