### PR TITLE
Fix worker-manager project name

### DIFF
--- a/infrastructure/k8s/services/worker-manager.yaml
+++ b/infrastructure/k8s/services/worker-manager.yaml
@@ -1,4 +1,4 @@
-project_name: "worker-manager"
+project_name: "taskcluster-worker-manager"
 secrets:
   azure_account: ".Values.tfAzureAccount"
   force_ssl: "false"


### PR DESCRIPTION
We missed the taskcluster prefix when porting tf.

This will make the service name match what the ingress expects.

https://github.com/sciurus/taskcluster/blob/master/infrastructure/terraform/worker-manager-service.tf#L15