### PR TITLE
Remove line breaks in base64

### DIFF
--- a/infrastructure/terraform/bin/create-random-secrets.sh
+++ b/infrastructure/terraform/bin/create-random-secrets.sh
@@ -3,7 +3,7 @@ set -u
 
 # will not work for > 130
 function genpw () {
-    openssl rand -base64 94 | cut -c1-"$1"
+    openssl rand -base64 94 |  tr -d '\n' | cut -c1-"$1"
 }
 
 genpw 32 > auth_azure_crypto_key


### PR DESCRIPTION
openssl's base64 output is wrapped after 64 characters. This fixes that.

Before 

```
# openssl rand -base64 94 | cut -c1-66
sIRvPoU8/7BDQUIzZIaCI7mkKd1QJEExLAFBQBVktOo0pWuU7kFGNGu2eGfni6vI
gbTaOhryCtEM6TomoCESoIRABE6hTsBpdo21hTcj7rbRf0fBApXxK1yHuvMrrA==
```

generated two 64 character lines.

After

```
$ openssl rand -base64 94 |  tr -d '\n' | cut -c1-66
5DaTI8B/el7ZgzF0vcvGkDQdZ8d1bMIGp0uNlqHerWtLJkrjSyj/HDuFn7sGMtzi6Z
```

generated one 66 character lines.

This means that all passwords we generated before that we thought were 65 characters were actually 64 characters.