### PR TITLE
Do not need aws region variable

### DIFF
--- a/infrastructure/terraform/auth-service.tf
+++ b/infrastructure/terraform/auth-service.tf
@@ -1,3 +1,5 @@
+data "aws_caller_identity" "current" {}
+
 module "auth_rabbitmq_user" {
   source         = "modules/rabbitmq-user"
   prefix         = "${var.prefix}"

--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -11,9 +11,6 @@ provider "rabbitmq" {
   endpoint = "https://${var.rabbitmq_hostname}"
 }
 
-data "aws_caller_identity" "current" {}
-data "aws_region" "current" {}
-
 resource "aws_s3_bucket" "private_artifacts" {
   bucket = "${var.prefix}-private-artifacts"
   acl    = "private"

--- a/infrastructure/terraform/variables.tf
+++ b/infrastructure/terraform/variables.tf
@@ -8,10 +8,6 @@ variable "azure_region" {
   description = "Region of azure storage"
 }
 
-variable "aws_region" {
-  description = "The AWS region to deploy into (e.g. us-east-1)."
-}
-
 variable "rabbitmq_hostname" {
   type        = "string"
   description = "rabbitmq hostname"


### PR DESCRIPTION
This data is available from the provider, and we aren't using it anyway.

See also https://github.com/mozilla-services/cloudops-infra/pull/1114
