### PR TITLE
Some random string must be base64 encoded

### DIFF
--- a/infrastructure/terraform/bin/create-random-secrets.sh
+++ b/infrastructure/terraform/bin/create-random-secrets.sh
@@ -6,9 +6,12 @@ function genpw () {
     openssl rand -base64 94 |  tr -d '\n' | cut -c1-"$1"
 }
 
-genpw 32 > auth_azure_crypto_key
-genpw 32 > hooks_azure_crypto_key
-genpw 32 > secrets_azure_crypto_key
+# these require an extra pass of base64 encoding to make the services happy
+genpw 32 | base64 > auth_azure_crypto_key
+genpw 32 | base64 > hooks_azure_crypto_key
+genpw 32 | base64 > secrets_azure_crypto_key
+
+# these do not
 genpw 40 > auth_azure_signing_key
 genpw 40 > hooks_azure_signing_key
 genpw 40 > secrets_azure_signing_key

--- a/infrastructure/terraform/bin/create-random-secrets.sh
+++ b/infrastructure/terraform/bin/create-random-secrets.sh
@@ -1,17 +1,21 @@
 #!/bin/bash
 set -u
 
+# for generating a random password of a given length
 # will not work for > 130
 function genpw () {
     openssl rand -base64 94 |  tr -d '\n' | cut -c1-"$1"
 }
 
-# these require an extra pass of base64 encoding to make the services happy
-genpw 32 | base64 > auth_azure_crypto_key
-genpw 32 | base64 > hooks_azure_crypto_key
-genpw 32 | base64 > secrets_azure_crypto_key
+# for generating a random number bytes of a given length after being decoded
+function genkey() {
+    openssl rand -base64 $1
+}
 
-# these do not
+genkey 32 > auth_azure_crypto_key
+genkey 32 > hooks_azure_crypto_key
+genkey 32 > secrets_azure_crypto_key
+
 genpw 40 > auth_azure_signing_key
 genpw 40 > hooks_azure_signing_key
 genpw 40 > secrets_azure_signing_key


### PR DESCRIPTION
Instead of just accepting a 32 character string, these variables are
base64-decoded by the app, and the output of that must be 32 characters.


In the original terraform

```
terraform/hooks-service.tf
40:    TABLE_CRYPTO_KEY         = "${base64encode(random_string.hooks_table_crypto_key.result)}"

terraform/secrets-service.tf
33:    AZURE_CRYPTO_KEY         = "${base64encode(random_string.secrets_azure_crypto_key.result)}"

terraform/auth-service.tf
222:    AZURE_CRYPTO_KEY  = "${base64encode(random_string.auth_table_crypto_key.result)}"
```
