### PR TITLE
Enable everything and delete events

### DIFF
--- a/infrastructure/k8s/ingress/ingress.yaml
+++ b/infrastructure/k8s/ingress/ingress.yaml
@@ -37,35 +37,31 @@ spec:
          backend:
            serviceName:  taskcluster-secrets
            servicePort: 80
-#       - path: '/api/queue/*'
-#         backend:
-#           serviceName:  taskcluster-queue
-#           servicePort: 80
-#       - path: '/api/hooks/*'
-#         backend:
-#           serviceName:  taskcluster-hooks
-#           servicePort: 80
+       - path: '/api/queue/*'
+         backend:
+           serviceName:  taskcluster-queue
+           servicePort: 80
+       - path: '/api/hooks/*'
+         backend:
+           serviceName:  taskcluster-hooks
+           servicePort: 80
        - path: '/api/index/*'
          backend:
            serviceName:  taskcluster-index
            servicePort: 80
-#       - path: '/api/events/*'
-#         backend:
-#           serviceName:  taskcluster-events
-#           servicePort: 80
-#       - path: '/api/notify/*'
-#         backend:
-#           serviceName:  taskcluster-notify
-#           servicePort: 80
+       - path: '/api/notify/*'
+         backend:
+           serviceName:  taskcluster-notify
+           servicePort: 80
        - path: '/api/purge-cache/*'
          backend:
            serviceName:  taskcluster-purge-cache
            servicePort: 80
-#       - path: '/api/github/*'
-#         backend:
-#           serviceName:  taskcluster-github
-#           servicePort: 80
-#       - path: '/api/worker-manager/*'
-#         backend:
-#           serviceName:  taskcluster-worker-manager
-#           servicePort: 80
+       - path: '/api/github/*'
+         backend:
+           serviceName:  taskcluster-github
+           servicePort: 80
+       - path: '/api/worker-manager/*'
+         backend:
+           serviceName:  taskcluster-worker-manager
+           servicePort: 80


### PR DESCRIPTION
No harm in enabling everything that is deployed, working or not.

Events service no longer exists.